### PR TITLE
Pubids & Pubid to config

### DIFF
--- a/YearInReview.py
+++ b/YearInReview.py
@@ -17,7 +17,7 @@ import plotly.graph_objects as go
 # 10     DC Comics
 # 2707   Marvel Digital Comics Unlimited
 
-KeepTypes = ['Print', 'One-Shot', 'Digital', 'None']
+KeepTypes = ['Print', 'One-Shot', 'Digital', 'None', 'GN', 'HC', 'TPB']
 #All Types: One-Shot, Print, None, Reprint, HC, TPB, Digital, GN
 
 minYear = 1930
@@ -136,15 +136,17 @@ def main():
                 'SELECT * FROM volumes WHERE "CV Series PublisherID" = ? AND "CV Series Year" = ?',
                 (pubid, year),
                 ).fetchall()
-            
+
             if not len(allSeries) == 0:
                 countAllSeries = len(allSeries)
                 lines = []
                 y = 0
-                file = '[' + allSeries[0][5] + '] ' + str(year) + '.html'
-                yearChart.append(year)
                 publisherChart = allSeries[0][5]
+                publisherChart = publisherChart.replace("/", "-")  # Replace "/" with "-"
+                file = '[' + publisherChart + '] ' + str(year) + '.html'
+                yearChart.append(year)
                 outputhtmlfile = os.path.join(YearInReviewDirectory, file)
+
                 
                 for x in allSeries:
                     #print(allSeries)
@@ -249,6 +251,7 @@ def main():
                             ]).set_caption(summaryText).map(color_cels)#.format({'CV Issue URL': make_clickable})#.to_html(outputhtmlfile)#,formatters={'CV Cover Image': image_formatter}, escape=False)
                 df.to_html(outputhtmlfile)
 
+            publisherChart = publisherChart.replace("/", "-")
             chartfilename = '[' + publisherChart + '] Summary Chart.html'
             chartTitle = publisherChart + ' Summary ' + datetime.today().strftime("%Y-%B-%d")
             outputchartfile = os.path.join(YearInReviewDirectory, chartfilename)

--- a/pubids.txt
+++ b/pubids.txt
@@ -4,18 +4,27 @@
 89 EC
 101 Archie
 125 Charlton
+144 Comic Media
+173 Warren
+178 Western Publishing
 252 Atlas Comics
+278 Waro Graphics
 285 Eclipse
+291 Capital Comics
+321 Catalan Communications
+336 Comico
 337 Continuity
 367 Eternity
 364 Dark Horse
 447 Malibu
 485 Valiant/Acclaim # Special character (/) in name breaks HTML parsing currently.
 488 Antarctic Press
+496 Harris Comics
 513 image
 519 Topps
 530 Bongo
 536 Heavy Metal
+573 Caliber
 591 London Night Studios
 600 Verotik
 606 Top Cow
@@ -28,32 +37,54 @@
 824 Aircel
 1092 Fantaco
 1099 Crossgen
+1112 Dreamwave Productions
 1859 Dynamite
 1862 Aspen MLT
 1863 Devil's Due
 1864 Chaos! Comics
+1865 UDON
 1868 Boom! Studios
 1870 Awesome Comics
 1899 Basement Comics
 1923 Fathom Press
 1968 Broadsword Comics
 1986 Zenescope Entertainment
+2004 Darkchylde Entertainment
+2007 DeadBox Art Studio
 2045 Dead Dog
 2019 Rebellion
+2068 Dabel Brothers Productions
 2073 Coffin Comics
 2104 Aftershock Comics
 2133 Asylum Press
 2186 Fangoria
 2244 Brainstorm
+2250 Express Publications
+2344 Cinebook
+2496 Big Dog Ink
+2521 Exploding Albatross Funnybooks
 2634 Aria Press
+2698 Cherry Comics
 2800 Bagheera
+2805 Dark Fantasy Productions
+2946 Comic Zone Productions
+3521 MonkeyBrain Comics
+3957 Trendmaster Comix
 4266 Black Mask Studios
 4417 Blue Juice Comics
+5850 Tiny Donkey Studios
+5974 Top Secret Press
 6338 Avery Hill Publishing
 6683 Benitez Publishing
+6816 Double Take
 6984 Scout Comics
+7385 Mad Cave Studios
 7369 American Mythology Productions
+7801 Vault Comics
+8773 Cave Pictures Publishing
+8916 Swords & Sassery
 9506 Death Rattle
+10430 Wicked Comics
 11141 Rodent Entertainment
 11154 Blood Moon Comics
 11160 Erie County Comics Inc
@@ -68,3 +99,4 @@
 11251 Red Leaf Comics
 11255 Ethereal Comics
 11257 Darkside Comics
+63177 Space Goat Productions

--- a/pubids.txt
+++ b/pubids.txt
@@ -17,7 +17,7 @@
 367 Eternity
 364 Dark Horse
 447 Malibu
-485 Valiant/Acclaim # Special character (/) in name breaks HTML parsing currently.
+485 Valiant/Acclaim
 488 Antarctic Press
 496 Harris Comics
 513 image
@@ -68,7 +68,9 @@
 2800 Bagheera
 2805 Dark Fantasy Productions
 2946 Comic Zone Productions
+3510 AAM/Markosia
 3521 MonkeyBrain Comics
+3755 Amigo Comica
 3957 Trendmaster Comix
 4266 Black Mask Studios
 4417 Blue Juice Comics
@@ -81,6 +83,7 @@
 7385 Mad Cave Studios
 7369 American Mythology Productions
 7801 Vault Comics
+8600 Ahoy Comics
 8773 Cave Pictures Publishing
 8916 Swords & Sassery
 9506 Death Rattle
@@ -99,4 +102,5 @@
 11251 Red Leaf Comics
 11255 Ethereal Comics
 11257 Darkside Comics
+59995 Red 5 Comics
 63177 Space Goat Productions

--- a/pubidtoconfig.py
+++ b/pubidtoconfig.py
@@ -1,0 +1,41 @@
+import re
+import configparser
+
+def extract_pubids(filename):
+    pubids = []
+    with open(filename, 'r') as file:
+        for line in file:
+            # Extract numerical digits from the line
+            digits = re.findall(r'\d+', line)
+            if digits:
+                # Convert the digits into a comma-separated value string
+                pubid = ','.join(digits)
+                pubids.append(pubid)
+    return pubids
+
+def write_to_config(pubids, config_filename):
+    config = configparser.ConfigParser()
+    # Read existing config file if it exists
+    config.read(config_filename)
+
+    # Check if [yearinreview] section exists, create if not
+    if 'yearinreview' not in config:
+        config['yearinreview'] = {}
+
+    # Write pubidsetting value to the [yearinreview] section
+    config['yearinreview']['pubidsetting'] = ','.join(pubids)
+
+    # Write the updated config file
+    with open(config_filename, 'w') as configfile:
+        config.write(configfile)
+
+def main():
+    pubids = extract_pubids('pubids.txt')
+    if pubids:
+        write_to_config(pubids, 'config.ini')
+        print('pubidsetting values have been successfully written to config.ini.')
+    else:
+        print('No valid pubid values found in pubids.txt.')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This includes another 30+ publishers for the starter set and a utility that allows for adding and removing to pubids.txt and creating an accurate config.ini entry compatible with the latest version of the yearinreview.py script. All text is stripped so users are free to annotate as needed provided they only use line breaks to enter new publishers.