### PR TITLE
[fix] plotly == not => and stop blank configPRIVATE.ini creation in mylarpubtoconfig

### DIFF
--- a/mylarpubtoconfig.py
+++ b/mylarpubtoconfig.py
@@ -100,7 +100,7 @@ def main():
     write_to_text_file(unique_values, mylar_publishers_file)
 
     # Match values from two text files and prepend numerical values
-    pubids_file_path = 'pubidsall.txt'
+    pubids_file_path = 'superpubids.txt'
     match_and_prepend_values(pubids_file_path, mylar_publishers_file)
 
     # Parse numerical values and write back to config.ini

--- a/mylarpubtoconfig.py
+++ b/mylarpubtoconfig.py
@@ -40,12 +40,6 @@ def read_unique_values_from_database(database_path, column_name):
 
     return unique_values
 
-# Function to write unique values to a text file
-def write_to_text_file(values, file_path):
-    with open(file_path, 'w') as file:
-        for value in values:
-            file.write(value + '\n')
-
 # Function to match values from two text files and prepend numerical values
 def match_and_prepend_values(pubids_file_path, mylar_publishers_file_path):
     matched_values = []
@@ -97,10 +91,9 @@ def main():
     # Read unique values from database and write to text file
     unique_values = read_unique_values_from_database(database_path, 'ComicPublisher')
     mylar_publishers_file = 'mylarpublishers.txt'
-    write_to_text_file(unique_values, mylar_publishers_file)
 
     # Match values from two text files and prepend numerical values
-    pubids_file_path = 'superpubids.txt'
+    pubids_file_path = 'pubidsall.txt'
     match_and_prepend_values(pubids_file_path, mylar_publishers_file)
 
     # Parse numerical values and write back to config.ini

--- a/mylarpubtoconfig.py
+++ b/mylarpubtoconfig.py
@@ -1,17 +1,24 @@
 import sqlite3
 import configparser
+import os
 
 # Function to read the database path from config.ini or configPRIVATE.ini
 def read_database_path(config_ini_path):
-    config = configparser.ConfigParser()
-    config.read(config_ini_path)
-    if 'mylar' in config and 'mylardb' in config['mylar']:
-        return config['mylar']['mylardb']
+    if os.path.exists(config_ini_path):
+        config = configparser.ConfigParser()
+        config.read(config_ini_path)
+        if 'mylar' in config and 'mylardb' in config['mylar']:
+            return config['mylar']['mylardb']
     return None
 
 # Function to update both config files with the database path
 def update_config_files(database_path):
-    for config_file in ['config.ini', 'configPRIVATE.ini']:
+    if os.path.exists('configPRIVATE.ini'):
+        config_files = ['config.ini', 'configPRIVATE.ini']
+    else:
+        config_files = ['config.ini']
+
+    for config_file in config_files:
         config = configparser.ConfigParser()
         config.read(config_file)
         if 'mylar' not in config:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pandas==2.1.3
 requests==2.31.0
 Simyan==1.2.0
 image==1.5.33
-plotly=>5.2.0
+plotly==5.2.0


### PR DESCRIPTION
The requirements.txt would error as I didn't realize python's requirements modules don't accept => as a value, just explicitly defined though I suspect I just dyslexiced it and >= would work.

mylarpubtoconfig had previously unnoticed issue where it creates a configPRIVATE.ini with only the pubid setting and nothing else if none already exists, added an update to check on whether the configPRIVATE.ini exists and have verified it does not create one now breaking other scripts' functionality.

Also corrected to repo provided superpubids.txt as I used a different naming when testing/building and looks like that was what had been pushed.