### PR TITLE
Fix to match decimal issue numbers

### DIFF
--- a/leagueHTMLtoReadingList.py
+++ b/leagueHTMLtoReadingList.py
@@ -71,7 +71,7 @@ def main():
                 series = series.replace("–", "-")
 
                 issuerange = titleNumSplit[1].strip()
-                allnums = re.findall(r'\d+', issuerange)
+                allnums = re.findall(r'\d+(?:\.\d+)?', issuerange)
 
                 if allnums:
                     issuenumber = allnums[0]

--- a/pubidtoconfig.py
+++ b/pubidtoconfig.py
@@ -6,7 +6,7 @@ def extract_pubids(filename):
     with open(filename, 'r') as file:
         for line in file:
             # Extract numerical digits from the line
-            digits = re.findall(r'\d+(?:\.\d+)?', line)
+            digits = re.findall(r'\d+', line)
             if digits:
                 # Convert the digits into a comma-separated value string
                 pubid = ','.join(digits)

--- a/pubidtoconfig.py
+++ b/pubidtoconfig.py
@@ -6,7 +6,7 @@ def extract_pubids(filename):
     with open(filename, 'r') as file:
         for line in file:
             # Extract numerical digits from the line
-            digits = re.findall(r'\d+', line)
+            digits = re.findall(r'\d+(?:\.\d+)?', line)
             if digits:
                 # Convert the digits into a comma-separated value string
                 pubid = ','.join(digits)

--- a/textToReadingList.py
+++ b/textToReadingList.py
@@ -196,7 +196,7 @@ for root, dirs, files in os.walk(readingListDirectory):
                                 issuerange = titleNumSplit[1]
                                 issuerange = issuerange.strip()
                                 #print(issuerange)
-                                issueNumPattern = r'\d+|\d+.\d+'
+                                issueNumPattern = r'\d+(?:\.\d+)?'
                                 #issueNumPattern = r'\d+'
                                 allnums = re.findall(issueNumPattern ,issuerange)
                                 #print(len(allnums))

--- a/textToReadingList.py
+++ b/textToReadingList.py
@@ -50,7 +50,7 @@ dfOrderList = ['SeriesName', 'SeriesStartYear', 'IssueNum', 'IssueType', 'CoverD
 index = 0
 
 def getRange(issuerange):
-    numbers = re.findall(r'\d+', issuerange)
+    numbers = re.findall(r'\d+(?:\.\d+)?', issuerange)
 
     # Convert the numbers to integers and extract the range
     num_range = list(range(int(numbers[0]), int(numbers[1])+1))
@@ -279,7 +279,7 @@ for root, dirs, files in os.walk(readingListDirectory):
                                             df.loc[index,'IssueNum'] = issue
                                             df.loc[index,'SeriesStartYear'] = year
                                             index += 1
-                                        issuelist = re.findall(r'\d+', issuerange)
+                                        issuelist = re.findall(r'\d+(?:\.\d+)?', issuerange)
                                     
                                         print(series)
                                         print(issue)
@@ -294,7 +294,7 @@ for root, dirs, files in os.walk(readingListDirectory):
                                         
                                     if re.search(fromToPatternEnd, issuerange) and re.search(threeCommaPatternBeg, issuerange):
                                         issueFromTo = re.sub(twoCommaPatternBeg,'', issuerange)
-                                        issuelist = re.findall(r'\d+', issueFromTo)
+                                        issuelist = re.findall(r'\d+(?:\.\d+)?', issueFromTo)
                                         print(series)
                                         print(issue)
                                         df.loc[index,'SeriesName'] = series


### PR DESCRIPTION
The scripts were not properly matching issue numbers with decimals (e.g., # 1.5). I updated the regex with an optional non-matching group to catch the decimal portion as well.

**Old regex:** `\d+`
**New regex:** `\d+(?:\.\d+)?`

You can see the [regex test on regex101.com](https://regex101.com/r/DcLWsK/1)